### PR TITLE
fix: add missing import + publish workflow on merge

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -52,3 +52,20 @@ jobs:
           dependencytrack_hostname: ${{ vars.DEPENDENCYTRACK_HOSTNAME }}
           dependencytrack_apikey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
           sbom_artifacts: 'build-artifacts'
+
+  publish:
+    name: Publish module
+    needs: build
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      credentials:
+        username: ${{ secrets.GH_PACKAGES_USERNAME }}
+        password: ${{ secrets.GH_PACKAGES_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jahia/jahia-modules-action/publish@v2
+        with:
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/src/javascript/init.js
+++ b/src/javascript/init.js
@@ -1,7 +1,8 @@
 import {registry} from '@jahia/ui-extender';
 import register from './jwt/App.register';
 // Ensure @apollo/react-hooks is bundled as a shared Module Federation dependency
-// eslint-disable next-line no-undef
+// eslint-disable-next-line no-unused-vars
+import {useQuery} from '@apollo/react-hooks'; // NOSONAR
 
 export default function () {
     registry.add('callback', 'securityfiltertools', {


### PR DESCRIPTION
Fixes #70 

The import statement of **@apollo/react-hooks** was missing (due to a linter operation at push time) making the lib not shared.

This fixes the issue.

Also the modules wasn't publish to Nexus in merge workflow