### PR TITLE
chore: Set Jahia parent version to 8.1.9.0

### DIFF
--- a/.chachalog/sg-q4A-z.md
+++ b/.chachalog/sg-q4A-z.md
@@ -3,4 +3,4 @@
 security-filter-tools: patch
 ---
 
-Set minimum jahia supported version to 8.1.9.0. The module is compatible only with Jahia versions 8.1.9.0 to 8.2 (excluded), 8.2.2.0 to 8.2.3 (excluded), and 8.2.4.0 or higher — it will not start outside these ranges. (#76)
+Set minimum jahia supported version to 8.1.9.2. The module is compatible only with Jahia versions 8.1.9.2 to 8.2 (excluded), 8.2.2.2 to 8.2.3.0 (excluded), and 8.2.3.1 or higher — it will not start outside these ranges. (#76)

--- a/.chachalog/sg-q4A-z.md
+++ b/.chachalog/sg-q4A-z.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+security-filter-tools: patch
+---
+
+Set minimum jahia supported version to 8.1.9.0. The module is compatible only with Jahia versions 8.1.9.0 to 8.2 (excluded), 8.2.2.0 to 8.2.3 (excluded), and 8.2.4.0 or higher — it will not start outside these ranges. (#76)

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.2.4.0-SNAPSHOT</version>
+        <version>8.1.9.0</version>
     </parent>
 
     <artifactId>security-filter-tools</artifactId>


### PR DESCRIPTION
Fixes #75
### Description

Jahia parent version set to 8.1.9.0 to match the release requirements: https://github.com/Jahia/security-filter-tools/issues/68

The module can't start on a not supported jahia version because of missing requirements:
```
Unable to resolve security-filter-tools [167](R 167.2): missing requirement [security-filter-tools [167](R 167.2)] osgi.wiring.package; (osgi.wiring.package=com.auth0.jwt) Unresolved requirements: [[security-filter-tools [167](R 167.2)] osgi.wiring.package; (osgi.wiring.package=com.auth0.jwt)]
```
