### PR TITLE
feat: set version to 2.6.1-SNAPSHOT + make the module start with older jahia versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     </parent>
 
     <artifactId>security-filter-tools</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Jahia API security config and filter tools</name>
     <description>Jahia API security config and filter tools</description>
@@ -69,13 +69,9 @@
     <properties>
         <jahia-module-type>system</jahia-module-type>
         <jahia-depends>graphql-dxm-provider</jahia-depends>
-        <jahia-module-signature>MC0CFAiw8vBP/S5l05ysOh33I5wmSIo7AhUAjUgOhGDdmxf2dsA0RxPQE4g2J6w=</jahia-module-signature>
-        <jahia.plugin.version>6.9</jahia.plugin.version>
+        <jahia-module-signature>MCwCFEg0Ns0xbSEk7APCxgjOTAKs9b5eAhQm+ofRErocskU6hCDo37RtXSV4Bg==</jahia-module-signature>
+        <jahia.plugin.version>6.14.0</jahia.plugin.version>
         <import-package>
-            com.auth0.jwt,
-            com.auth0.jwt.interfaces,
-            com.auth0.jwt.exceptions,
-            com.auth0.jwt.algorithms,
             com.fasterxml.jackson.core;version="[2.10,3)",
             com.fasterxml.jackson.databind;version="[2.10,3)",
             javax.jcr;version="[2.0,3)",
@@ -142,6 +138,14 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
+                        <Import-Package>
+                            com.auth0.jwt;resolution:=optional,
+                            com.auth0.jwt.interfaces;resolution:=optional,
+                            com.auth0.jwt.exceptions;resolution:=optional,
+                            com.auth0.jwt.algorithms;resolution:=optional,
+                            ${jahia.plugin.projectPackageImport},
+                            *
+                        </Import-Package>
                         <_dsannotations>*</_dsannotations>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
### Description
In order to ease the rolling upgrade, this PR make the module starting and providing the same capabilities on any Jahia version. 

The module is not compatible as it requires export from Jahia of `com.auth0.jwt` packages.
Those packages are required to start the moved JWT service from jahia core to this module.
The rest of the module is working as before.

The strategy is to make optional those packages, this way:
- The module can start, it works as before on older vesion of jahia
- The service is not started on old version, avoiding to have 2 JWT services in parallel. 

### Maven jahia plugin bug
Due to a bug in **maven jahia plugin**, it is not possible to set all package as optional in the default property to configure import packages.
The bug removes the optional statement of the first import package entry. 
To solve that, the import package have been declared outside of the **maven jahia plugin** resolution. 


### Testing
Do a sanity check on "previous" (8.2.x and 8.1.x) released version of jahia. 